### PR TITLE
Corrected unsafe call to fprintf in report.c

### DIFF
--- a/swmm/swmm5/swmm5/report.c
+++ b/swmm/swmm5/swmm5/report.c
@@ -1373,7 +1373,7 @@ void report_writeErrorCode()
         if ( (ErrorCode >= ERR_MEMORY && ErrorCode <= ERR_TIMESTEP)
         ||   (ErrorCode >= ERR_FILE_NAME && ErrorCode <= ERR_OUT_FILE)
         ||   (ErrorCode == ERR_SYSTEM) )
-            fprintf(Frpt.file, error_getMsg(ErrorCode));
+			fputs(Frpt.file, error_getMsg(ErrorCode));
     }
 }
 

--- a/swmm/swmm5/swmm5/swmm5.c
+++ b/swmm/swmm5/swmm5/swmm5.c
@@ -63,7 +63,6 @@
 #endif
 ////
 
-#include <direct.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
gcc fails to compile report.c due to the unsafe use of fprintf (line 1376). fputs should be used instead. More details in this thread:
http://stackoverflow.com/q/17260409/2066215
